### PR TITLE
Ignore existing null values

### DIFF
--- a/StructureCopy.php
+++ b/StructureCopy.php
@@ -44,9 +44,9 @@ class StructureCopy
                 continue;
             }
 
-            if (\is_scalar($value) ||null === $value)
+            if (\is_scalar($value) || null === $value)
             {
-                if (isset($target[$key]))
+                if (\array_key_exists($key, $target))
                 {
                     $merged[$key] = $target[$key];
                 }

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
     "name": "becklyn/yaml-parameters",
     "description": "Composer script handling the dist parameters file.",
-    "license": "BSD-3-Clause",
     "homepage": "https://github.com/Becklyn/YamlParameters",
+    "license": "BSD-3-Clause",
     "authors": [
         {
             "name": "Becklyn Studios",
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^7.1",
-        "symfony/yaml": "^3.0|^4.0"
+        "symfony/yaml": "^3.0 || ^4.0"
     },
     "require-dev": {
         "composer/composer": "^1.0",
@@ -19,9 +19,13 @@
         "symfony/phpunit-bridge": "^4.0"
     },
     "autoload": {
-        "psr-4": { "Becklyn\\YamlParameters\\": "" }
+        "psr-4": {
+            "Becklyn\\YamlParameters\\": ""
+        }
     },
     "autoload-dev": {
-        "psr-4": { "Becklyn\\YamlParameters\\Tests\\": "tests/" }
+        "psr-4": {
+            "Becklyn\\YamlParameters\\Tests\\": "tests/"
+        }
     }
 }

--- a/tests/YamlProcessorTest.php
+++ b/tests/YamlProcessorTest.php
@@ -123,4 +123,27 @@ class YamlProcessorTest extends TestCase
 
         self::assertEquals(["parameters" => ["a" => 1, "b" => 5, "c" => 3]], $out);
     }
+
+
+    /**
+     * Tests, that existing null values are not asked for
+     */
+    public function testSkipExistingNull ()
+    {
+        $this->setUpFixtures();
+        $io = $this->getMockBuilder(IOInterface::class)->getMock();
+
+        $io
+            ->expects(self::once())
+            ->method("ask")
+            ->willReturnArgument(1);
+
+        $processor = new YamlProcessor($io);
+        $processor->process("{$this->fixtures}/skip_existing_null.yaml");
+
+        $yaml = new Parser();
+        $out = $yaml->parseFile("{$this->fixtures}/skip_existing_null.yaml");
+
+        self::assertEquals(["parameters" => ["a" => null, "b" => "sth"]], $out);
+    }
 }

--- a/tests/fixtures/skip_existing_null.dist.yaml
+++ b/tests/fixtures/skip_existing_null.dist.yaml
@@ -1,0 +1,3 @@
+parameters:
+    a: ~
+    b: "sth"

--- a/tests/fixtures/skip_existing_null.yaml
+++ b/tests/fixtures/skip_existing_null.yaml
@@ -1,0 +1,2 @@
+parameters:
+    a: ~


### PR DESCRIPTION
Existing `null` values are currently not honored.